### PR TITLE
Rewrite

### DIFF
--- a/src/vue-persist-decorator.ts
+++ b/src/vue-persist-decorator.ts
@@ -18,33 +18,36 @@ export function Persist(options: PersistOptions = {}): PropertyDecorator {
         const { key = `${name}_${k}`, default: defaultValue, expiry: expiryString } = options
 
         // Create an empty computed object if one doesn't exist in options already
-        if (typeof opts.computed !== 'object') {
-            opts.computed = Object.create(null)
+        if (typeof opts.watch !== 'object') {
+            opts.watch = Object.create(null)
         }
 
         // Create getter and setter
-        ;(opts.computed as any)[k] = {
-            get() {
-                const item = localStorage.getItem(key)
-                if (!item) return defaultValue
-
-                try {
-                    const data: PersistObject = JSON.parse(item)
-
-                    if (data.expiry && new Date(data.expiry).getTime() - Date.now() <= 0) {
-                        return defaultValue
-                    }
-
-                    return data.value
-                } catch (e) {
-                    return
-                }
-            },
-            set(value: any) {
+        ;(opts.watch as any)[k] = {
+            handler(value: any) {
                 const persist: PersistObject = { value }
                 if (expiryString) persist.expiry = parseRelativeTime(expiryString)
                 localStorage.setItem(key, JSON.stringify(persist))
             },
+            // get() {
+            //     const item = localStorage.getItem(key)
+            //     if (!item) return defaultValue
+
+            //     try {
+            //         const data: PersistObject = JSON.parse(item)
+
+            //         if (data.expiry && new Date(data.expiry).getTime() - Date.now() <= 0) {
+            //             return defaultValue
+            //         }
+
+            //         return data.value
+            //     } catch (e) {
+            //         return
+            //     }
+            // },
+            // set(value: any) {
+
+            // },
         }
     })
 }

--- a/src/vue-persist-decorator.ts
+++ b/src/vue-persist-decorator.ts
@@ -20,6 +20,9 @@ export function Persist(options: PersistOptions = {}): PropertyDecorator {
             opts.watch = Object.create(null)
         }
 
+        // Add mounted hook mixin to component to load stored values
+        opts.mixins = [...(opts.mixins || []), createMixin(key, k)]
+
         // Watch decorated property and store changes
         ;(opts.watch as any)[k] = {
             handler(value: any) {
@@ -46,4 +49,20 @@ export function parseRelativeTime(dateString: string): number {
     }
     const multiplier: number = extensions[dateArray[1]] || extensions.h
     return epoch + input * multiplier
+}
+
+export function createMixin(storageKey: string, property: string): any {
+    return {
+        mounted() {
+            const item = localStorage.getItem(storageKey)
+            if (!item) return
+            try {
+                const data: PersistObject = JSON.parse(item)
+                if (data.expiry && new Date(data.expiry).getTime() - Date.now() <= 0) return
+                this[property] = data.value
+            } catch (e) {
+                return
+            }
+        },
+    }
 }

--- a/src/vue-persist-decorator.ts
+++ b/src/vue-persist-decorator.ts
@@ -15,11 +15,6 @@ export function Persist(options: PersistOptions = {}): PropertyDecorator {
         const name = (opts.name || '_').toLowerCase()
         const { key = `${name}_${k}`, expiry: expiryString } = options
 
-        // Create an empty watch object if one doesn't exist in options already
-        if (typeof opts.watch !== 'object') {
-            opts.watch = Object.create(null)
-        }
-
         opts.mixins = [
             ...(opts.mixins || []),
             {

--- a/src/vue-persist-decorator.ts
+++ b/src/vue-persist-decorator.ts
@@ -3,19 +3,17 @@ import { createDecorator } from 'vue-class-component'
 export interface PersistOptions {
     expiry?: string
     key?: string
-    default?: any
 }
 
 export interface PersistObject {
     value: string
     expiry?: number
-    default?: any
 }
 
 export function Persist(options: PersistOptions = {}): PropertyDecorator {
     return createDecorator((opts, k) => {
         const name = (opts.name || '_').toLowerCase()
-        const { key = `${name}_${k}`, default: defaultValue, expiry: expiryString } = options
+        const { key = `${name}_${k}`, expiry: expiryString } = options
 
         // Create an empty computed object if one doesn't exist in options already
         if (typeof opts.watch !== 'object') {

--- a/src/vue-persist-decorator.ts
+++ b/src/vue-persist-decorator.ts
@@ -15,37 +15,18 @@ export function Persist(options: PersistOptions = {}): PropertyDecorator {
         const name = (opts.name || '_').toLowerCase()
         const { key = `${name}_${k}`, expiry: expiryString } = options
 
-        // Create an empty computed object if one doesn't exist in options already
+        // Create an empty watch object if one doesn't exist in options already
         if (typeof opts.watch !== 'object') {
             opts.watch = Object.create(null)
         }
 
-        // Create getter and setter
+        // Watch decorated property and store changes
         ;(opts.watch as any)[k] = {
             handler(value: any) {
                 const persist: PersistObject = { value }
                 if (expiryString) persist.expiry = parseRelativeTime(expiryString)
                 localStorage.setItem(key, JSON.stringify(persist))
             },
-            // get() {
-            //     const item = localStorage.getItem(key)
-            //     if (!item) return defaultValue
-
-            //     try {
-            //         const data: PersistObject = JSON.parse(item)
-
-            //         if (data.expiry && new Date(data.expiry).getTime() - Date.now() <= 0) {
-            //             return defaultValue
-            //         }
-
-            //         return data.value
-            //     } catch (e) {
-            //         return
-            //     }
-            // },
-            // set(value: any) {
-
-            // },
         }
     })
 }

--- a/tests/unit/persist.spec.ts
+++ b/tests/unit/persist.spec.ts
@@ -31,6 +31,7 @@ describe('Reading and writing', () => {
     })
 
     test('setting the property stores in localStorage', done => {
+        comp.$mount()
         comp.hello = 'hi'
 
         comp.$nextTick(() => {
@@ -97,6 +98,7 @@ describe('Automatic type casting on stored values', () => {
 describe('Expiry date', () => {
     test('expiry key is not added by default', done => {
         const comp = factory<string>('')
+        comp.$mount()
         comp.hello = 'hi'
 
         comp.$nextTick(() => {
@@ -109,6 +111,7 @@ describe('Expiry date', () => {
 
     test('adding expiry settings creates expiry prop as a date', done => {
         const comp = factory<string>('', { expiry: '2h' })
+        comp.$mount()
         comp.hello = 'hey'
 
         comp.$nextTick(() => {

--- a/tests/unit/persist.spec.ts
+++ b/tests/unit/persist.spec.ts
@@ -30,10 +30,14 @@ describe('Reading and writing', () => {
         expect(watch!.hello).toBeDefined()
     })
 
-    test('setting the property stores in localStorage', () => {
+    test('setting the property stores in localStorage', done => {
         comp.hello = 'hi'
-        const item = localStorage.getItem('comp_hello')
-        expect(item).toBe(JSON.stringify({ value: 'hi' }))
+
+        comp.$nextTick(() => {
+            const item = localStorage.getItem('comp_hello')
+            expect(item).toBe(JSON.stringify({ value: 'hi' }))
+            done()
+        })
     })
 
     test('getting the property from localStorage', () => {
@@ -91,21 +95,27 @@ describe('Automatic type casting on stored values', () => {
 })
 
 describe('Expiry date', () => {
-    test('expiry key is not added by default', () => {
+    test('expiry key is not added by default', done => {
         const comp = factory<string>('')
         comp.hello = 'hi'
 
-        const obj = JSON.parse(localStorage.getItem('comp_hello') || '')
-        expect(obj.value).toBe('hi')
-        expect(obj.expiry).toBeUndefined()
+        comp.$nextTick(() => {
+            const obj = JSON.parse(localStorage.getItem('comp_hello') || '{}')
+            expect(obj.value).toBe('hi')
+            expect(obj.expiry).toBeUndefined()
+            done()
+        })
     })
 
-    test('adding expiry settings creates expiry prop as a date', () => {
+    test('adding expiry settings creates expiry prop as a date', done => {
         const comp = factory<string>('', { expiry: '2h' })
         comp.hello = 'hey'
 
-        const obj = JSON.parse(localStorage.getItem('comp_hello') || '')
-        expect(obj.value).toBe('hey')
-        expect(new Date(obj.expiry).getDate()).not.toBeNaN()
+        comp.$nextTick(() => {
+            const obj = JSON.parse(localStorage.getItem('comp_hello') || '{}')
+            expect(obj.value).toBe('hey')
+            expect(new Date(obj.expiry).getDate()).not.toBeNaN()
+            done()
+        })
     })
 })

--- a/tests/unit/persist.spec.ts
+++ b/tests/unit/persist.spec.ts
@@ -7,11 +7,11 @@ declare var global: any
 
 global.localStorage = new LocalStorageMock()
 
-const factory = <T>(options?: PersistOptions, componentOptions?: any) => {
+const factory = <T>(value: T, options?: PersistOptions, componentOptions?: any) => {
     @Component(componentOptions)
     class Comp extends Vue {
         @Persist(options)
-        hello!: T
+        hello: T = value
     }
     return new Comp()
 }
@@ -21,13 +21,13 @@ beforeEach(() => localStorage.clear())
 describe('Reading and writing', () => {
     let comp: any
     beforeEach(() => {
-        comp = factory<string>()
+        comp = factory<string>('')
     })
 
-    test('a computed property is set which matches the name of the data property', () => {
-        const computed = comp.$options.computed
-        expect(computed).toBeDefined()
-        expect(computed!.hello).toBeDefined()
+    test('a watch object is set which matches the name of the data property', () => {
+        const watch = comp.$options.watch
+        expect(watch).toBeDefined()
+        expect(watch!.hello).toBeDefined()
     })
 
     test('setting the property stores in localStorage', () => {
@@ -44,60 +44,47 @@ describe('Reading and writing', () => {
 
 describe('Storage keys', () => {
     test('it uses the class name as a key by default', () => {
-        const comp = factory<string>()
+        const comp = factory<string>('')
         comp.hello = 'keys'
         expect(localStorage.getItem('comp_hello')).toBeDefined()
     })
 
     test('it uses the component name if manually set', () => {
-        const comp = factory<string>({}, { name: 'different' })
+        const comp = factory<string>('', {}, { name: 'different' })
         comp.hello = 'something different'
         expect(localStorage.getItem('different_hello')).toBeDefined()
     })
 
     test('default key name can be overridden using key option', () => {
-        const comp = factory<string>({ key: 'custom_key' })
+        const comp = factory<string>('', { key: 'custom_key' })
         comp.hello = 'custom'
         expect(localStorage.getItem('custom_key')).toBeDefined()
     })
 })
 
-describe('Default values', () => {
-    test('it returns the default value provided if the key is never set', () => {
-        const comp = factory<string>({ default: 'fall back to me' })
-        expect(comp.hello).toBe('fall back to me')
-    })
-
-    test('it does not return the default value if something exists in storage', () => {
-        localStorage.setItem('comp_hello', JSON.stringify({ value: 'should be me' }))
-        const comp = factory<string>({ default: 'fall back to me' })
-        expect(comp.hello).toBe('should be me')
-    })
-})
-
 describe('Automatic type casting on stored values', () => {
     test('string', () => {
-        const comp = factory<string>()
+        const comp = factory<string>('')
         comp.hello = 'hi'
         expect(typeof comp.hello).toBe('string')
     })
     test('number', () => {
-        const comp = factory<number>()
+        const comp = factory<number>(1)
         comp.hello = 3
         expect(typeof comp.hello).toBe('number')
     })
     test('object', () => {
-        const comp = factory<any>()
+        const comp = factory<any>({})
         comp.hello = { greet: 'tings' }
         expect(typeof comp.hello).toBe('object')
     })
     test('boolean', () => {
-        const comp = factory<boolean>()
+        const comp = factory<boolean>(false)
         comp.hello = true
         expect(typeof comp.hello).toBe('boolean')
     })
     test('array', () => {
-        const comp = factory<string[]>()
+        const comp = factory<string[]>([])
         comp.hello = ['hi', 'hello']
         expect(Array.isArray(comp.hello)).toBeTruthy()
     })
@@ -105,7 +92,7 @@ describe('Automatic type casting on stored values', () => {
 
 describe('Expiry date', () => {
     test('expiry key is not added by default', () => {
-        const comp = factory<string>()
+        const comp = factory<string>('')
         comp.hello = 'hi'
 
         const obj = JSON.parse(localStorage.getItem('comp_hello') || '')
@@ -114,7 +101,7 @@ describe('Expiry date', () => {
     })
 
     test('adding expiry settings creates expiry prop as a date', () => {
-        const comp = factory<string>({ expiry: '2h' })
+        const comp = factory<string>('', { expiry: '2h' })
         comp.hello = 'hey'
 
         const obj = JSON.parse(localStorage.getItem('comp_hello') || '')

--- a/tests/unit/persist.spec.ts
+++ b/tests/unit/persist.spec.ts
@@ -24,12 +24,6 @@ describe('Reading and writing', () => {
         comp = factory<string>('')
     })
 
-    test('a watch object is set which matches the name of the data property', () => {
-        const watch = comp.$options.watch
-        expect(watch).toBeDefined()
-        expect(watch!.hello).toBeDefined()
-    })
-
     test('setting the property stores in localStorage', done => {
         comp.$mount()
         comp.hello = 'hi'


### PR DESCRIPTION
Made a big mistake not testing the behaviour of computed properties beforehand.

Setting the value in localStorage does not trigger a recompute, can fix by forcing a render but this seems like a very bad idea.

This PR changes computed properties to a mixin for each persisted value, which restores the value on component mount and sets up a watcher for the persisted property.