### PR TITLE
Unit test to cover deep watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "devDependencies": {
         "@types/jest": "^23.3.9",
         "@vue/test-utils": "^1.0.0-beta.28",
+        "flush-promises": "^1.0.2",
         "jest": "^23.6.0",
         "jsdom": "^13.1.0",
         "jsdom-global": "^3.0.2",

--- a/tests/unit/persist.spec.ts
+++ b/tests/unit/persist.spec.ts
@@ -46,6 +46,23 @@ describe('Reading and writing', () => {
         const wrapper = mount(factory<string>(''))
         expect(wrapper.vm.hello).toBe('greetings')
     })
+
+    test('deep watching works', async done => {
+        const wrapper = mount(
+            factory<{ heck: string }>(
+                { heck: 'hello up there' },
+                { deep: true },
+                { template: `<div><input class="txt" v-model="hello.heck"></div>` },
+            ),
+        )
+        const input = wrapper.find('.txt')
+
+        input.setValue('updated text')
+        await flushPromises()
+        expect(wrapper.vm.hello.heck).toBe('updated text')
+        expect(localStorage.getItem('comp_hello')).toBe(JSON.stringify({ value: { heck: 'updated text' } }))
+        done()
+    })
 })
 
 describe('Storage keys', () => {

--- a/tests/unit/persist.spec.ts
+++ b/tests/unit/persist.spec.ts
@@ -1,6 +1,7 @@
 import 'jsdom-global/register'
 import Vue from 'vue'
 import Component from 'vue-class-component'
+import flushPromises from 'flush-promises'
 import { mount } from '@vue/test-utils'
 import { Persist, PersistOptions } from '../../src/vue-persist-decorator'
 import { LocalStorageMock } from '../mocks/localstorage.mock'
@@ -25,14 +26,14 @@ const factory = <T>(value: T, options?: PersistOptions, componentOptions?: any) 
 beforeEach(() => localStorage.clear())
 
 describe('Reading and writing', () => {
-    test('setting the property stores in localStorage', done => {
+    test('setting the property stores in localStorage', async done => {
         const wrapper = mount(factory<string>(''))
         wrapper.setData({ hello: 'hi' })
-        wrapper.vm.$nextTick(() => {
-            const item = localStorage.getItem('comp_hello')
-            expect(item).toBe(JSON.stringify({ value: 'hi' }))
-            done()
-        })
+        await flushPromises()
+
+        const item = localStorage.getItem('comp_hello')
+        expect(item).toBe(JSON.stringify({ value: 'hi' }))
+        done()
     })
 
     test('getting the property from localStorage', () => {
@@ -68,27 +69,25 @@ describe('Storage keys', () => {
 })
 
 describe('Expiry date', () => {
-    test('expiry key is not added by default', done => {
+    test('expiry key is not added by default', async done => {
         const wrapper = mount(factory<string>(''))
         wrapper.vm.hello = 'hi'
+        await flushPromises()
 
-        wrapper.vm.$nextTick(() => {
-            const obj = JSON.parse(localStorage.getItem('comp_hello') || '{}')
-            expect(obj.value).toBe('hi')
-            expect(obj.expiry).toBeUndefined()
-            done()
-        })
+        const obj = JSON.parse(localStorage.getItem('comp_hello') || '{}')
+        expect(obj.value).toBe('hi')
+        expect(obj.expiry).toBeUndefined()
+        done()
     })
 
-    test('adding expiry settings creates expiry prop as a date', done => {
+    test('adding expiry settings creates expiry prop as a date', async done => {
         const wrapper = mount(factory<string>('', { expiry: '2h' }))
         wrapper.vm.hello = 'hey'
+        await flushPromises()
 
-        wrapper.vm.$nextTick(() => {
-            const obj = JSON.parse(localStorage.getItem('comp_hello') || '{}')
-            expect(obj.value).toBe('hey')
-            expect(new Date(obj.expiry).getDate()).not.toBeNaN()
-            done()
-        })
+        const obj = JSON.parse(localStorage.getItem('comp_hello') || '{}')
+        expect(obj.value).toBe('hey')
+        expect(new Date(obj.expiry).getDate()).not.toBeNaN()
+        done()
     })
 })

--- a/tests/unit/persist.spec.ts
+++ b/tests/unit/persist.spec.ts
@@ -63,6 +63,28 @@ describe('Reading and writing', () => {
         expect(localStorage.getItem('comp_hello')).toBe(JSON.stringify({ value: { heck: 'updated text' } }))
         done()
     })
+
+    test('deep watching can be disabled', async done => {
+        const wrapper = mount(
+            factory<{ heck: string }>(
+                { heck: 'hello up there' },
+                { deep: false },
+                { template: `<div><input class="txt" v-model="hello.heck"></div>` },
+            ),
+        )
+        const input = wrapper.find('.txt')
+
+        input.setValue('updated text')
+        await flushPromises()
+        expect(wrapper.vm.hello.heck).toBe('updated text')
+        expect(localStorage.getItem('comp_hello')).toBeNull()
+
+        wrapper.vm.hello = { heck: 'full replace' }
+        await flushPromises()
+        expect(wrapper.vm.hello.heck).toBe('full replace')
+        expect(localStorage.getItem('comp_hello')).toBe(JSON.stringify({ value: { heck: 'full replace' } }))
+        done()
+    })
 })
 
 describe('Storage keys', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,6 +937,11 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+flush-promises@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flush-promises/-/flush-promises-1.0.2.tgz#4948fd58f15281fed79cbafc86293d5bb09b2ced"
+  integrity sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
Cover deep watching use cases with 2 new unit tests to make sure that it works correctly when toggled on or off.

I have also added the flush-promises package as a dev dependency, and replaced the $nextTick callback functions with an await to neaten up the tests a bit.